### PR TITLE
Fix missing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# roadtrippers
+# Roadtrippers
+
+## Setup
+
+1. Install dependencies:
+```bash
+npm install
+```
+
+2. Start the development server:
+```bash
+npm run dev
+```
+
+Visit http://localhost:5173 (or the port shown in the terminal) to see the app.
+
+3. Build for production:
+```bash
+npm run build
+```
+


### PR DESCRIPTION
## Summary
- add installation and dev server instructions to README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847775fb05c832381b85067c51001bc